### PR TITLE
Actual (2020.01) wamp packages and packages.conf

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
 # laragon-packages
-Standard WAMP packages for using with "Quick add".
+Standard WAMP packages for using with "Menu / Tools / Quick add".

--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
 # laragon-packages
-Standard packages for using with "Quick add"
+Standard WAMP packages for using with "Quick add".

--- a/packages.conf
+++ b/packages.conf
@@ -1,48 +1,51 @@
-# packages.conf v2020.01
+# packages.conf v2020.10
 ------------------------------------------------------
 # Apache
- apache-2.4.38-win64-VC11=https://home.apache.org/~steffenal/VC11/binaries/httpd-2.4.38-win64-VC11.zip
+*apache-2.4.46-win64-VC15=https://home.apache.org/~steffenal/VC15/binaries/httpd-2.4.46-win64-VC15.zip
  apache-2.4.41-win64-VC14=https://home.apache.org/~steffenal/VC14/binaries/httpd-2.4.41-win64-VC14.zip
-*apache-2.4.41-win64-VC15=https://home.apache.org/~steffenal/VC15/binaries/httpd-2.4.41-win64-VC15.zip
- apache-2.4.41-win64-VS16=https://www.apachelounge.com/download/VS16/binaries/httpd-2.4.41-win64-VS16.zip
+ apache-2.4.38-win64-VC11=https://home.apache.org/~steffenal/VC11/binaries/httpd-2.4.38-win64-VC11.zip
 
 ; Original files from [Apache Lounge](https://www.apachelounge.com/download/)
 
 ------------------------------------------------------
 # PHP
- php-5.6.40-Win32-VC11-x64=https://windows.php.net/downloads/releases/archives/php-5.6.40-Win32-VC11-x64.zip
+ php-7.4.10-Win32-vc15-x64=https://windows.php.net/downloads/releases/archives/php-7.4.10-Win32-vc15-x64.zip
+*php-7.3.22-Win32-VC15-x64=https://windows.php.net/downloads/releases/archives/php-7.3.22-Win32-VC15-x64.zip
+ php-7.2.33-Win32-VC15-x64=https://windows.php.net/downloads/releases/archives/php-7.2.33-Win32-VC14-x64.zip
  php-7.1.33-Win32-VC14-x64=https://windows.php.net/downloads/releases/archives/php-7.1.33-Win32-VC14-x64.zip
- php-7.2.25-Win32-VC15-x64=https://windows.php.net/downloads/releases/archives/php-7.2.25-Win32-VC14-x64.zip
-*php-7.3.12-Win32-VC15-x64=https://windows.php.net/downloads/releases/archives/php-7.3.12-Win32-VC15-x64.zip
- php-7.4.0-Win32-vc15-x64 =https://windows.php.net/downloads/releases/archives/php-7.4.0-Win32-vc15-x64.zip
+ php-7.0.33-Win32-VC14-x64=https://windows.php.net/downloads/releases/archives/php-7.0.33-Win32-VC14-x64.zip
+ php-5.6.40-Win32-VC11-x64=https://windows.php.net/downloads/releases/archives/php-5.6.40-Win32-VC11-x64.zip
  
 ; Latest versions from [archives](https://windows.php.net/downloads/releases/archives/). Current version's links change when new version released.
 
 ------------------------------------------------------
-# MySQL / MariaDB
-*mysql-5.7.28-winx64=https://github.com/zeon77/laragon-packages/releases/download/v2020.01/mysql-5.7.28-winx64.zip
- mysql-8.0.18-winx64=https://github.com/zeon77/laragon-packages/releases/download/v2020.01/mysql-8.0.18-winx64.zip
- mariadb-10.4.11-winx64=https://github.com/zeon77/laragon-packages/releases/download/v2020.01/mariadb-10.4.11-winx64.zip
+# MariaDB / MySQL
+ mariadb-10.5.5-winx64=https://github.com/zeon77/laragon-packages/releases/download/v2020.10/mariadb-10.5.5-winx64.zip
+; original: https://downloads.mariadb.org/interstitial/mariadb-10.5.5/winx64-packages/mariadb-10.5.5-winx64.zip
+ mysql-8.0.21-winx64=https://github.com/zeon77/laragon-packages/releases/download/v2020.10/mysql-8.0.21-winx64.zip
+; original: https://dev.mysql.com/get/Downloads/MySQL-8.0/mysql-8.0.21-winx64.zip
+*mysql-5.7.30-winx64=https://github.com/zeon77/laragon-packages/releases/download/v2020.10/mysql-5.7.30-winx64.zip
+; original: https://downloads.mysql.com/archives/get/p/23/file/mysql-5.7.30-winx64.zip
  
-; *bin\mysqld.pdb* file, *include* and *lib* folders removed from original [MySQL](https://dev.mysql.com/downloads/mysql/) / [MariaDB](https://downloads.mariadb.org/mariadb/+releases/) files.
+; **.pdb* files, *include* and *lib* folders removed from original [MySQL](https://dev.mysql.com/downloads/mysql/) / [MariaDB](https://downloads.mariadb.org/mariadb/+releases/) files to retain minimal file sizes.
 
 ------------------------------------------------------
 # phpMyAdmin
-*phpMyAdmin-4.9.3-all-languages=https://files.phpmyadmin.net/phpMyAdmin/4.9.3/phpMyAdmin-4.9.3-all-languages.zip
+*phpMyAdmin-4.9.5-all-languages=https://files.phpmyadmin.net/phpMyAdmin/4.9.5/phpMyAdmin-4.9.5-all-languages.zip
 
-; Older version compatible with PHP 5.5 to 7.4 and MySQL 5.5 and newer.
-; Multiple versions of phpMyAdmin not supported well currently by Laragon.
+; The older version (v4.9.x) compatible with PHP 5.5 to 7.4 and MySQL 5.5 and newer.
+; Current versions of phpMyAdmin (v5.0.x) currently not supported well by Laragon.
 
 ------------------------------------------------------
 # Nginx
- nginx-1.16.1=https://nginx.org/download/nginx-1.16.1.zip
- nginx-1.17.7=https://nginx.org/download/nginx-1.17.7.zip
+ nginx-1.19.3=https://nginx.org/download/nginx-1.19.3.zip
+ nginx-1.18.0=https://nginx.org/download/nginx-1.18.0.zip
 
 ------------------------------------------------------
 # Git
- git-2.24.1.2-64-bit=https://github.com/zeon77/laragon-packages/releases/download/v2020.01/git-2.24.1.2-64-bit.zip
+ git-2.28.0-64-bit=https://github.com/zeon77/laragon-packages/releases/download/v2020.10/git-2.28.0-64-bit.zip
  
-; [PortableGit-2.24.1.2-64-bit.7z.exe](https://github.com/git-for-windows/git/releases/download/v2.24.1.windows.2/PortableGit-2.24.1.2-64-bit.7z.exe) repackaged in .zip format.
+; [PortableGit-2.28.0-64-bit.7z.exe](https://github.com/git-for-windows/git/releases/download/v2.28.0.windows.1/PortableGit-2.28.0-64-bit.7z.exe) repackaged in .zip format.
 
 ------------------------------------------------------
 # VSCode

--- a/packages.conf
+++ b/packages.conf
@@ -1,0 +1,57 @@
+# packages.conf v2020.01
+------------------------------------------------------
+# Apache
+ apache-2.4.38-win64-VC11=https://home.apache.org/~steffenal/VC11/binaries/httpd-2.4.38-win64-VC11.zip
+ apache-2.4.41-win64-VC14=https://home.apache.org/~steffenal/VC14/binaries/httpd-2.4.41-win64-VC14.zip
+*apache-2.4.41-win64-VC15=https://home.apache.org/~steffenal/VC15/binaries/httpd-2.4.41-win64-VC15.zip
+ apache-2.4.41-win64-VS16=https://www.apachelounge.com/download/VS16/binaries/httpd-2.4.41-win64-VS16.zip
+
+; Original files from [Apache Lounge](https://www.apachelounge.com/download/)
+
+------------------------------------------------------
+# PHP
+ php-5.6.40-Win32-VC11-x64=https://windows.php.net/downloads/releases/archives/php-5.6.40-Win32-VC11-x64.zip
+ php-7.1.33-Win32-VC14-x64=https://windows.php.net/downloads/releases/archives/php-7.1.33-Win32-VC14-x64.zip
+ php-7.2.25-Win32-VC15-x64=https://windows.php.net/downloads/releases/archives/php-7.2.25-Win32-VC14-x64.zip
+*php-7.3.12-Win32-VC15-x64=https://windows.php.net/downloads/releases/archives/php-7.3.12-Win32-VC15-x64.zip
+ php-7.4.0-Win32-vc15-x64 =https://windows.php.net/downloads/releases/archives/php-7.4.0-Win32-vc15-x64.zip
+ 
+; Latest versions from [archives](https://windows.php.net/downloads/releases/archives/). Current version's links change when new version released.
+
+------------------------------------------------------
+# MySQL / MariaDB
+*mysql-5.7.28-winx64=https://github.com/zeon77/laragon-packages/releases/download/v2020.01/mysql-5.7.28-winx64.zip
+ mysql-8.0.18-winx64=https://github.com/zeon77/laragon-packages/releases/download/v2020.01/mysql-8.0.18-winx64.zip
+ mariadb-10.4.11-winx64=https://github.com/zeon77/laragon-packages/releases/download/v2020.01/mariadb-10.4.11-winx64.zip
+ 
+; *bin\mysqld.pdb* file, *include* and *lib* folders removed from original [MySQL](https://dev.mysql.com/downloads/mysql/) / [MariaDB](https://downloads.mariadb.org/mariadb/+releases/) files.
+
+------------------------------------------------------
+# phpMyAdmin
+*phpMyAdmin-4.9.3-all-languages=https://files.phpmyadmin.net/phpMyAdmin/4.9.3/phpMyAdmin-4.9.3-all-languages.zip
+
+; Older version compatible with PHP 5.5 to 7.4 and MySQL 5.5 and newer.
+; Multiple versions of phpMyAdmin not supported well currently by Laragon.
+
+------------------------------------------------------
+# Nginx
+ nginx-1.16.1=https://nginx.org/download/nginx-1.16.1.zip
+ nginx-1.17.7=https://nginx.org/download/nginx-1.17.7.zip
+
+------------------------------------------------------
+# Git
+ git-2.24.1.2-64-bit=https://github.com/zeon77/laragon-packages/releases/download/v2020.01/git-2.24.1.2-64-bit.zip
+ 
+; [PortableGit-2.24.1.2-64-bit.7z.exe](https://github.com/git-for-windows/git/releases/download/v2.24.1.windows.2/PortableGit-2.24.1.2-64-bit.7z.exe) repackaged in .zip format.
+
+------------------------------------------------------
+# VSCode
+*vscode=https://go.microsoft.com/fwlink/?Linkid=850641
+
+; Always links the current version.
+
+------------------------------------------------------
+# packages.conf
+; For an existing version of Laragon, you can overwrite the file ([Laragon folder]\usr\packages.conf), or you can manually edit the file in **Laragon > Menu > Tools > Quick add > Configuration...**
+
+------------------------------------------------------


### PR DESCRIPTION
Check my release: [https://github.com/zeon77/laragon-packages/releases](https://github.com/zeon77/laragon-packages/releases)